### PR TITLE
PagedAttention Initial

### DIFF
--- a/attentions/pa.py
+++ b/attentions/pa.py
@@ -1,40 +1,162 @@
-import torch
-import math
-class PagedAttention(torch.nn.Module):
-    def __init__(self, config, block_size: int = 64):
-        super().__init__()
-        self.hidden_size = config.hidden_size
-        self.num_heads = config.num_attention_heads
-        self.head_dim = self.hidden_size // self.num_heads
-        self.block_size = block_size
-        
-        self.q_proj = torch.nn.Linear(self.hidden_size, self.hidden_size)
-        self.k_proj = torch.nn.Linear(self.hidden_size, self.hidden_size)
-        self.v_proj = torch.nn.Linear(self.hidden_size, self.hidden_size)
-        self.o_proj = torch.nn.Linear(self.hidden_size, self.hidden_size)
+# Lightweight paged-KV attention
 
-    def forward(self, hidden_states, attention_mask=None):
+from __future__ import annotations
+from typing import Optional, Tuple, Union
+
+import math
+import torch
+import torch.nn.functional as F
+from bitsandbytes.nn import Linear4bit
+
+
+class PagedAttention(torch.nn.Module):
+    def __init__(
+        self,
+        config,
+        block_size: int = 64,
+        *,
+        use_bias: bool = False,
+    ):
+        super().__init__()
+
+        self.hidden_size: int = config.hidden_size
+        self.num_heads: int = getattr(
+            config, "num_attention_heads", getattr(config, "n_heads", None)
+        )
+        if self.num_heads is None:
+            raise ValueError("Could not infer number of heads from config")
+
+        # Some configs (Mistral, Llama-2/3) have separate kv-heads
+        self.num_key_value_heads: int = getattr(
+            config, "num_key_value_heads", self.num_heads
+        )
+        self.head_dim: int = self.hidden_size // self.num_heads
+        self.scale: float = self.head_dim ** -0.5
+
+        self.block_size: int = block_size
+        self.max_position_embeddings: int = getattr(
+            config, "max_position_embeddings", 8192
+        )
+
+        proj_cls = Linear4bit if hasattr(config, "quantization_config") else torch.nn.Linear
+
+        self.q_proj = proj_cls(self.hidden_size, self.hidden_size, bias=use_bias)
+        self.k_proj = proj_cls(self.hidden_size, self.hidden_size, bias=use_bias)
+        self.v_proj = proj_cls(self.hidden_size, self.hidden_size, bias=use_bias)
+        self.o_proj = proj_cls(self.hidden_size, self.hidden_size, bias=use_bias)
+
+        # Run-time KV cache (allocated lazily on first decode step)
+        self.register_buffer("k_cache", None, persistent=False)
+        self.register_buffer("v_cache", None, persistent=False)
+        self.register_buffer("cache_index", torch.zeros(1, dtype=torch.long), persistent=False)
+
+    # keep pretrained weights when we swap modules
+    @torch.no_grad()
+    def copy_from(self, other_attn: torch.nn.Module) -> None:
+        """
+        Shallow-copies the projection sub-modules from an existing
+        attention layer (useful when we replace HF’s stock module
+        with PagedAttention but want to preserve the weights).
+        """
+        for name in ("q_proj", "k_proj", "v_proj", "o_proj"):
+            setattr(self, name, getattr(other_attn, name))
+        # remove the original module from the parameter list so that
+        # optimizer / LoRA see only one copy
+        other_attn.__dict__.clear()
+
+    def forward(
+        self,
+        hidden_states: torch.FloatTensor,                      # (B, T, D)
+        attention_mask: Optional[torch.Tensor] = None,         # (B, 1, T, S) in HF
+        position_ids: Optional[torch.LongTensor] = None,       # ignore
+        past_key_value: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]], Optional[torch.Tensor]]:
+
+        bsz, tgt_len, _ = hidden_states.size()
         q = self.q_proj(hidden_states)
         k = self.k_proj(hidden_states)
         v = self.v_proj(hidden_states)
-        
-        # Split into blocks
-        bs, seq_len, _ = q.shape
-        q = q.view(bs, seq_len // self.block_size, self.block_size, self.num_heads, self.head_dim)
-        k = k.view(bs, seq_len // self.block_size, self.block_size, self.num_heads, self.head_dim)
-        v = v.view(bs, seq_len // self.block_size, self.block_size, self.num_heads, self.head_dim)
-        
-        # Process blocks sequentially
-        outputs = []
-        for i in range(q.size(1)):
-            q_block = q[:, i]
-            k_block = k[:, :i+1]
-            v_block = v[:, :i+1]
-            
-            scores = torch.einsum("bqhgd,bkhgd->bhqk", q_block, k_block) / math.sqrt(self.head_dim)
-            attn_weights = torch.softmax(scores, dim=-1)
-            block_output = torch.einsum("bhqk,bkhgd->bqhg", attn_weights, v_block)
-            outputs.append(block_output)
-            
-        output = torch.cat(outputs, dim=1)
-        return self.o_proj(output.contiguous().view(bs, seq_len, -1))
+
+        # (B, T, H, Hd)  ->  (B, H, T, Hd)
+        def _reshape(x, n_heads):
+            return x.view(bsz, tgt_len, n_heads, self.head_dim).transpose(1, 2)
+
+        q = _reshape(q, self.num_heads)
+        k = _reshape(k, self.num_key_value_heads)
+        v = _reshape(v, self.num_key_value_heads)
+
+        # append to / concatenate KV cache if provided
+        has_past = (
+            past_key_value is not None
+            and len(past_key_value) == 2
+            and all(t is not None for t in past_key_value)
+        )
+        if has_past:
+            past_k, past_v = past_key_value          # (B, n_kv, S, Hd)
+            k = torch.cat([past_k, k], dim=2)
+            v = torch.cat([past_v, v], dim=2)
+
+        kv_seq_len = k.size(2)
+
+        # save cache for decoding
+        new_past_kv = None
+        if use_cache:
+            new_past_kv = (k, v)
+
+        # build mask
+        attn_mask = None
+        if attention_mask is not None:
+            # (B, S)  -> (B, 1, 1, S)
+            if attention_mask.dim() == 2:
+                attention_mask = attention_mask[:, None, None, :]
+
+            # keep / pad so the last dim == kv_seq_len
+            s = attention_mask.size(-1)
+            if s < kv_seq_len:                                   # pad with 0 (no mask)
+                pad = torch.zeros(
+                    attention_mask.shape[:-1] + (kv_seq_len - s,),
+                    dtype=attention_mask.dtype,
+                    device=attention_mask.device,
+                )
+                attention_mask = torch.cat([attention_mask, pad], dim=-1)
+            elif s > kv_seq_len:
+                attention_mask = attention_mask[..., :kv_seq_len]
+
+            # broadcast over heads & queries. H/Q singleton dims
+            if attention_mask.size(1) == 1 and self.num_heads > 1:
+                attention_mask = attention_mask.expand(bsz, 1, tgt_len, kv_seq_len)
+
+            attn_mask = attention_mask                       # final (B,1,Q,K) tensor
+
+        # scaled dot-product attention
+        attn_output = F.scaled_dot_product_attention(
+            q, k, v,
+            attn_mask=attn_mask,
+            dropout_p=0.0,
+            scale=self.scale,
+        )                                       # (B, H, T, Hd)
+
+        attn_output = attn_output.transpose(1, 2).contiguous()  # (B, T, H, Hd)
+        attn_output = attn_output.view(bsz, tgt_len, self.hidden_size)
+        attn_output = self.o_proj(attn_output)
+
+        attn_probs = None
+        if output_attentions:
+            score = (q * self.scale) @ k.transpose(2, 3)        # (B, H, T, S)
+            if attention_mask is not None:
+                score = score + attention_mask
+            attn_probs = score.softmax(dim=-1)
+
+        if output_attentions and use_cache:
+            return (attn_output, attn_probs, (k, v))
+        elif output_attentions:
+            return (attn_output, attn_probs)
+        elif use_cache:
+            return (attn_output, (k, v))
+        else:
+            # HF still expects a second dummy element when both flags are False
+            return (attn_output, None)

--- a/model_FA.py
+++ b/model_FA.py
@@ -1,0 +1,773 @@
+import math
+from dataclasses import dataclass
+from typing import Tuple, Optional, Literal
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+import torch.distributed as dist
+from flash_attn.flash_attn_interface import flash_attn_func
+
+
+from kernel import act_quant, weight_dequant, fp8_gemm
+
+import os, torch
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
+torch.set_default_dtype(torch.float16)      # smaller dtype
+
+
+world_size = 1
+rank = 0
+block_size = 128
+gemm_impl: Literal["bf16", "fp8"] = "bf16"
+attn_impl: Literal["naive", "absorb"] = "absorb"
+
+@dataclass
+class ModelArgs:
+    """
+    Data class for defining model arguments and hyperparameters.
+
+    Attributes:
+        max_batch_size (int): Maximum batch size.
+        max_seq_len (int): Maximum sequence length.
+        dtype (Literal["bf16", "fp8"]): Data type for computations.
+        vocab_size (int): Vocabulary size.
+        dim (int): Model dimension.
+        inter_dim (int): Intermediate dimension for MLP layers.
+        moe_inter_dim (int): Intermediate dimension for MoE layers.
+        n_layers (int): Number of transformer layers.
+        n_dense_layers (int): Number of dense layers in the model.
+        n_heads (int): Number of attention heads.
+        n_routed_experts (int): Number of routed experts for MoE layers.
+        n_shared_experts (int): Number of shared experts for MoE layers.
+        n_activated_experts (int): Number of activated experts in MoE layers.
+        n_expert_groups (int): Number of expert groups.
+        n_limited_groups (int): Number of limited groups for MoE routing.
+        score_func (Literal["softmax", "sigmoid"]): Scoring function for MoE routing.
+        route_scale (float): Scaling factor for routing scores.
+        q_lora_rank (int): LoRA rank for query projections.
+        kv_lora_rank (int): LoRA rank for key-value projections.
+        qk_nope_head_dim (int): Dimension for query-key projections without positional embeddings.
+        qk_rope_head_dim (int): Dimension for query-key projections with rotary embeddings.
+        v_head_dim (int): Dimension for value projections.
+        original_seq_len (int): Original sequence length.
+        rope_theta (float): Base for rotary positional encoding.
+        rope_factor (float): Scaling factor for extended sequence lengths.
+        beta_fast (int): Fast beta correction factor.
+        beta_slow (int): Slow beta correction factor.
+        mscale (float): Scaling factor for extended attention.
+    """
+    max_batch_size: int = 8
+    max_seq_len: int = 4096 * 4
+    dtype: Literal["bf16", "fp8"] = "bf16"
+    vocab_size: int = 102400
+    dim: int = 2048
+    inter_dim: int = 10944
+    moe_inter_dim: int = 1408
+    n_layers: int = 27
+    n_dense_layers: int = 1
+    n_heads: int = 16
+    # moe
+    n_routed_experts: int = 64
+    n_shared_experts: int = 2
+    n_activated_experts: int = 6
+    n_expert_groups: int = 1
+    n_limited_groups: int = 1
+    score_func: Literal["softmax", "sigmoid"] = "softmax"
+    route_scale: float = 1.
+    # mla
+    q_lora_rank: int = 0
+    kv_lora_rank: int = 512
+    qk_nope_head_dim: int = 128
+    qk_rope_head_dim: int = 64
+    v_head_dim: int = 128
+    # yarn
+    original_seq_len: int = 4096
+    rope_theta: float = 10000.0
+    rope_factor: float = 40
+    beta_fast: int = 32
+    beta_slow: int = 1
+    mscale: float = 1.
+
+
+class ParallelEmbedding(nn.Module):
+    """
+    Embedding layer with parallelism support across distributed processes.
+
+    Args:
+        vocab_size (int): Vocabulary size.
+        dim (int): Embedding dimension.
+    """
+    def __init__(self, vocab_size: int, dim: int):
+        super().__init__()
+        self.vocab_size = vocab_size
+        self.dim = dim
+        assert vocab_size % world_size == 0, f"Vocabulary size must be divisible by world size (world_size={world_size})"
+        self.part_vocab_size = (vocab_size // world_size)
+        self.vocab_start_idx = rank * self.part_vocab_size
+        self.vocab_end_idx = self.vocab_start_idx + self.part_vocab_size
+        self.weight = nn.Parameter(torch.empty(self.part_vocab_size, self.dim))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass for parallel embedding layer.
+
+        Args:
+            x (torch.Tensor): Input tensor containing token indices.
+
+        Returns:
+            torch.Tensor: Embedded representations.
+
+        Raises:
+            ValueError: If `world_size` is not defined.
+        """
+        if world_size > 1:
+            mask = (x < self.vocab_start_idx) | (x >= self.vocab_end_idx)
+            x = x - self.vocab_start_idx
+            x[mask] = 0
+        y = F.embedding(x, self.weight)
+        if world_size > 1:
+            y[mask] = 0
+            dist.all_reduce(y)
+        return y
+
+
+def linear(x: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+    """
+    Applies a linear transformation to the incoming data: y = xA^T + b.
+    This function supports specialized implementations based on quantization
+    and tensor formats.
+
+    Args:
+        x (torch.Tensor): The input tensor.
+        weight (torch.Tensor): The weight tensor. It may be quantized and 
+            requires dequantization for certain cases.
+        bias (Optional[torch.Tensor]): The bias tensor to be added. Default is None.
+
+    Returns:
+        torch.Tensor: The result of the linear transformation, which may involve 
+        quantization-aware computations depending on the input parameters.
+
+    Notes:
+        - If `weight` is quantized (e.g., `element_size() == 1`), a dequantized version 
+          is used for computation.
+        - If `gemm_impl == "bf16"`, dequantization and a `bf16` GEMM operation are applied.
+        - For other cases, the function applies quantization to `x` and uses `fp8_gemm` for computation.
+    """
+    if weight.element_size() > 1:
+        return F.linear(x, weight, bias)
+    elif gemm_impl == "bf16":
+        weight = weight_dequant(weight, weight.scale)
+        return F.linear(x, weight, bias)
+    else:
+        x, scale = act_quant(x, block_size)
+        y = fp8_gemm(x, scale, weight, weight.scale)
+        if bias is not None:
+            y += bias
+        return y
+
+
+class Linear(nn.Module):
+    """
+    Custom linear layer with support for quantized weights and optional bias.
+
+    Args:
+        in_features (int): Number of input features.
+        out_features (int): Number of output features.
+        bias (bool): Whether to include a bias term. Defaults to False.
+        dtype (optional): Data type for the layer. Defaults to `torch.bfloat16`.
+    """
+    dtype = torch.bfloat16
+
+    def __init__(self, in_features: int, out_features: int, bias: bool = False, dtype = None):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = nn.Parameter(torch.empty(out_features, in_features, dtype=dtype or Linear.dtype))
+        if self.weight.element_size() == 1:
+            scale_out_features = (out_features + block_size - 1) // block_size
+            scale_in_features = (in_features + block_size - 1) // block_size
+            self.weight.scale = self.scale = nn.Parameter(torch.empty(scale_out_features, scale_in_features, dtype=torch.float32))
+        else:
+            self.register_parameter("scale", None)
+        if bias:
+            self.bias = nn.Parameter(torch.empty(out_features))
+        else:
+            self.register_parameter("bias", None)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass for the custom linear layer.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Transformed tensor after linear computation.
+        """
+        return linear(x, self.weight, self.bias)
+
+
+class ColumnParallelLinear(Linear):
+    """
+    Linear layer with column parallelism, splitting output features across distributed processes.
+
+    Args:
+        in_features (int): Number of input features.
+        out_features (int): Total number of output features.
+        bias (bool): Whether to include a bias term. Defaults to False.
+        dtype (optional): Data type for the layer. Defaults to `torch.bfloat16`.
+    """
+    def __init__(self, in_features: int, out_features: int, bias: bool = False, dtype = None):
+        assert out_features % world_size == 0, f"Output features must be divisible by world size (world_size={world_size})"
+        self.part_out_features = out_features // world_size
+        super().__init__(in_features, self.part_out_features, bias, dtype)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass for column parallel linear layer.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Transformed tensor with column-parallel computation.
+        """
+        y = linear(x, self.weight, self.bias)
+        return y
+
+
+class RowParallelLinear(Linear):
+    """
+    Linear layer with row parallelism, splitting input features across distributed processes.
+
+    Args:
+        in_features (int): Total number of input features.
+        out_features (int): Number of output features.
+        bias (bool): Whether to include a bias term. Defaults to False.
+        dtype (optional): Data type for the layer. Defaults to `torch.bfloat16`.
+    """
+    def __init__(self, in_features: int, out_features: int, bias: bool = False, dtype = None):
+        assert in_features % world_size == 0, f"Input features must be divisible by world size (world_size={world_size})"
+        self.part_in_features = in_features // world_size
+        super().__init__(self.part_in_features, out_features, bias, dtype)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass for row parallel linear layer.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Transformed tensor with row-parallel computation.
+        """
+        y = linear(x, self.weight)
+        if world_size > 1:
+            dist.all_reduce(y)
+        if self.bias is not None:
+            y += self.bias
+        return y
+
+
+class RMSNorm(nn.Module):
+    """
+    Root Mean Square Layer Normalization (RMSNorm).
+
+    Args:
+        dim (int): Dimension of the input tensor.
+        eps (float): Epsilon value for numerical stability. Defaults to 1e-6.
+    """
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.dim = dim
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x: torch.Tensor):
+        """
+        Forward pass for RMSNorm.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Normalized tensor with the same shape as input.
+        """
+        return F.rms_norm(x, (self.dim,), self.weight, self.eps)
+
+
+def precompute_freqs_cis(args: ModelArgs) -> torch.Tensor:
+    """
+    Precomputes frequency-based complex exponential values for rotary positional embeddings.
+
+    Args:
+        args (ModelArgs): Model arguments containing positional embedding parameters.
+
+    Returns:
+        torch.Tensor: Precomputed complex exponential values for positional embeddings.
+    """
+    dim = args.qk_rope_head_dim
+    seqlen = args.max_seq_len
+    beta_fast = args.beta_fast
+    beta_slow = args.beta_slow
+    base = args.rope_theta
+    factor = args.rope_factor
+
+    def find_correction_dim(num_rotations, dim, base, max_seq_len):
+        """
+        Computes the correction dimension for a given number of rotations in the rotary positional embedding.
+
+        Args:
+            num_rotations (float): Number of rotations to compute the correction for.
+            dim (int): Dimensionality of the embedding space.
+            base (float): Base value for the exponential computation.
+            max_seq_len (int): Maximum sequence length.
+
+        Returns:
+            float: The correction dimension based on the input parameters.
+        """
+        return dim * math.log(max_seq_len / (num_rotations * 2 * math.pi)) / (2 * math.log(base))
+
+    def find_correction_range(low_rot, high_rot, dim, base, max_seq_len):
+        """
+        Computes the range of correction dimensions for rotary positional embeddings.
+
+        Args:
+            low_rot (float): Lower bound for the number of rotations.
+            high_rot (float): Upper bound for the number of rotations.
+            dim (int): Dimensionality of the embedding space.
+            base (float): Base value for the exponential computation.
+            max_seq_len (int): Maximum sequence length.
+
+        Returns:
+            Tuple[int, int]: The range of correction dimensions (low, high), clamped to valid indices.
+        """
+        low = math.floor(find_correction_dim(low_rot, dim, base, max_seq_len))
+        high = math.ceil(find_correction_dim(high_rot, dim, base, max_seq_len))
+        return max(low, 0), min(high, dim-1)
+
+    def linear_ramp_factor(min, max, dim):
+        """
+        Computes a linear ramp function used to smooth values between a minimum and maximum range.
+
+        Args:
+            min (float): Minimum value for the ramp function.
+            max (float): Maximum value for the ramp function.
+            dim (int): Dimensionality of the ramp tensor.
+
+        Returns:
+            torch.Tensor: A tensor of shape (dim,) with values linearly interpolated between 0 and 1,
+                clamped to the range [0, 1].
+        """
+        if min == max:
+            max += 0.001
+        linear_func = (torch.arange(dim, dtype=torch.float32) - min) / (max - min)
+        ramp_func = torch.clamp(linear_func, 0, 1)
+        return ramp_func
+
+    freqs = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+    if seqlen > args.original_seq_len:
+        low, high = find_correction_range(beta_fast, beta_slow, dim, base, args.original_seq_len)
+        smooth = 1 - linear_ramp_factor(low, high, dim // 2)
+        freqs = freqs / factor * (1 - smooth) + freqs * smooth
+
+    t = torch.arange(seqlen)
+    freqs = torch.outer(t, freqs)
+    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)
+    return freqs_cis
+
+
+def apply_rotary_emb(x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+    """
+    Applies rotary positional embeddings to the input tensor.
+
+    Args:
+        x (torch.Tensor): Input tensor with positional embeddings to be applied.
+        freqs_cis (torch.Tensor): Precomputed complex exponential values for positional embeddings.
+
+    Returns:
+        torch.Tensor: Tensor with rotary embeddings applied.
+    """
+    dtype = x.dtype
+    x = torch.view_as_complex(x.float().view(*x.shape[:-1], -1, 2))
+    freqs_cis = freqs_cis.view(1, x.size(1), 1, x.size(-1))
+    y = torch.view_as_real(x * freqs_cis).flatten(3)
+    return y.to(dtype)
+
+# ---------------------------------------------------------------------------
+# Flash‑based Multi‑Head Attention layer
+# ---------------------------------------------------------------------------
+
+
+def _flash_attn(q, k, v, dropout_p=0.0, scale=None, causal=True):
+    """Wrapper around flash_attn_func that keeps the (B, S, H, D) layout."""
+    out, _ = flash_attn_func(q, k, v, dropout_p=dropout_p,
+                             softmax_scale=scale, causal=causal)
+    return out  # (B, S, H, D)
+
+
+class FlashMHA(nn.Module):
+    """Standard MHA built on FlashAttention + rotary positional encoding."""
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.dim = args.dim
+        self.n_heads = args.n_heads
+        assert self.dim % self.n_heads == 0, "`dim` must be divisible by `n_heads`."
+        self.head_dim = self.dim // self.n_heads
+
+        # QKV projections – column‑parallel so shards across GPUs
+        self.wqkv = ColumnParallelLinear(self.dim, 3 * self.dim)
+        self.wo = RowParallelLinear(self.dim, self.dim)
+        self.scale = self.head_dim ** -0.5  # used in FlashAttention
+
+    def forward(self, x: torch.Tensor, start_pos: int, freqs_cis: torch.Tensor, mask=None):
+        # x: (B, S, dim)
+        B, S, _ = x.shape
+        qkv = self.wqkv(x)                        # (B, S, 3*dim_local)
+        qkv = qkv.view(B, S, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.unbind(dim=2)               # each: (B, S, H, D)
+
+        # rotary positional embedding (in‑place on q and k)
+        q = apply_rotary_emb(q, freqs_cis[start_pos:start_pos+S])
+        k = apply_rotary_emb(k, freqs_cis[start_pos:start_pos+S])
+
+        # FlashAttention expects contiguous tensors
+        q, k, v = q.contiguous(), k.contiguous(), v.contiguous()
+        out = _flash_attn(q, k, v, dropout_p=0.0, scale=self.scale, causal=True)  # (B, S, H, D)
+        out = out.view(B, S, self.dim)
+        return self.wo(out)
+
+
+class MLP(nn.Module):
+    """
+    Multi-Layer Perceptron (MLP) used as a feed-forward layer.
+
+    Attributes:
+        w1 (nn.Module): Linear layer for input-to-hidden transformation.
+        w2 (nn.Module): Linear layer for hidden-to-output transformation.
+        w3 (nn.Module): Additional linear layer for feature transformation.
+    """
+    def __init__(self, dim: int, inter_dim: int):
+        """
+        Initializes the MLP layer.
+
+        Args:
+            dim (int): Input and output dimensionality.
+            inter_dim (int): Hidden layer dimensionality.
+        """
+        super().__init__()
+        self.w1 = ColumnParallelLinear(dim, inter_dim)
+        self.w2 = RowParallelLinear(inter_dim, dim)
+        self.w3 = ColumnParallelLinear(dim, inter_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass for the MLP layer.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Output tensor after MLP computation.
+        """
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+
+class Gate(nn.Module):
+    """
+    Gating mechanism for routing inputs in a mixture-of-experts (MoE) model.
+
+    Attributes:
+        dim (int): Dimensionality of input features.
+        topk (int): Number of top experts activated for each input.
+        n_groups (int): Number of groups for routing.
+        topk_groups (int): Number of groups to route inputs to.
+        score_func (str): Scoring function ('softmax' or 'sigmoid').
+        route_scale (float): Scaling factor for routing weights.
+        weight (torch.nn.Parameter): Learnable weights for the gate.
+        bias (Optional[torch.nn.Parameter]): Optional bias term for the gate.
+    """
+    def __init__(self, args: ModelArgs):
+        """
+        Initializes the Gate module.
+
+        Args:
+            args (ModelArgs): Model arguments containing gating parameters.
+        """
+        super().__init__()
+        self.dim = args.dim
+        self.topk = args.n_activated_experts
+        self.n_groups = args.n_expert_groups
+        self.topk_groups = args.n_limited_groups
+        self.score_func = args.score_func
+        self.route_scale = args.route_scale
+        self.weight = nn.Parameter(torch.empty(args.n_routed_experts, args.dim))
+        self.bias = nn.Parameter(torch.empty(args.n_routed_experts)) if self.dim == 7168 else None
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Forward pass for the gating mechanism.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]: Routing weights and selected expert indices.
+        """
+        scores = linear(x, self.weight)
+        if self.score_func == "softmax":
+            scores = scores.softmax(dim=-1, dtype=torch.float32)
+        else:
+            scores = scores.sigmoid()
+        original_scores = scores
+        if self.bias is not None:
+            scores = scores + self.bias
+        if self.n_groups > 1:
+            scores = scores.view(x.size(0), self.n_groups, -1)
+            if self.bias is None:
+                group_scores = scores.amax(dim=-1)
+            else:
+                group_scores = scores.topk(2, dim=-1)[0].sum(dim=-1)
+            indices = group_scores.topk(self.topk_groups, dim=-1)[1]
+            mask = scores.new_ones(x.size(0), self.n_groups, dtype=bool).scatter_(1, indices, False)
+            scores = scores.masked_fill_(mask.unsqueeze(-1), float("-inf")).flatten(1)
+        indices = torch.topk(scores, self.topk, dim=-1)[1]
+        weights = original_scores.gather(1, indices)
+        if self.score_func == "sigmoid":
+            weights /= weights.sum(dim=-1, keepdim=True)
+        weights *= self.route_scale
+        return weights.type_as(x), indices
+
+
+class Expert(nn.Module):
+    """
+    Expert layer for Mixture-of-Experts (MoE) models.
+
+    Attributes:
+        w1 (nn.Module): Linear layer for input-to-hidden transformation.
+        w2 (nn.Module): Linear layer for hidden-to-output transformation.
+        w3 (nn.Module): Additional linear layer for feature transformation.
+    """
+    def __init__(self, dim: int, inter_dim: int):
+        """
+        Initializes the Expert layer.
+
+        Args:
+            dim (int): Input and output dimensionality.
+            inter_dim (int): Hidden layer dimensionality.
+        """
+        super().__init__()
+        self.w1 = Linear(dim, inter_dim)
+        self.w2 = Linear(inter_dim, dim)
+        self.w3 = Linear(dim, inter_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass for the Expert layer.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Output tensor after expert computation.
+        """
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+
+class MoE(nn.Module):
+    """
+    Mixture-of-Experts (MoE) module.
+
+    Attributes:
+        dim (int): Dimensionality of input features.
+        n_routed_experts (int): Total number of experts in the model.
+        n_local_experts (int): Number of experts handled locally in distributed systems.
+        n_activated_experts (int): Number of experts activated for each input.
+        gate (nn.Module): Gating mechanism to route inputs to experts.
+        experts (nn.ModuleList): List of expert modules.
+        shared_experts (nn.Module): Shared experts applied to all inputs.
+    """
+    def __init__(self, args: ModelArgs):
+        """
+        Initializes the MoE module.
+
+        Args:
+            args (ModelArgs): Model arguments containing MoE parameters.
+        """
+        super().__init__()
+        self.dim = args.dim
+        assert args.n_routed_experts % world_size == 0, f"Number of experts must be divisible by world size (world_size={world_size})"
+        self.n_routed_experts = args.n_routed_experts
+        self.n_local_experts = args.n_routed_experts // world_size
+        self.n_activated_experts = args.n_activated_experts
+        self.experts_start_idx = rank * self.n_local_experts
+        self.experts_end_idx = self.experts_start_idx + self.n_local_experts
+        self.gate = Gate(args)
+        self.experts = nn.ModuleList([Expert(args.dim, args.moe_inter_dim) if self.experts_start_idx <= i < self.experts_end_idx else None
+                                      for i in range(self.n_routed_experts)])
+        self.shared_experts = MLP(args.dim, args.n_shared_experts * args.moe_inter_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass for the MoE module.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Output tensor after expert routing and computation.
+        """
+        shape = x.size()
+        x = x.view(-1, self.dim)
+        weights, indices = self.gate(x)
+        y = torch.zeros_like(x)
+        counts = torch.bincount(indices.flatten(), minlength=self.n_routed_experts).tolist()
+        for i in range(self.experts_start_idx, self.experts_end_idx):
+            if counts[i] == 0:
+                continue
+            expert = self.experts[i]
+            idx, top = torch.where(indices == i)
+            y[idx] += expert(x[idx]) * weights[idx, top, None]
+        z = self.shared_experts(x)
+        if world_size > 1:
+            dist.all_reduce(y)
+        return (y + z).view(shape)
+
+
+class Block(nn.Module):
+    """
+    Transformer block combining attention and feed-forward layers.
+
+    Attributes:
+        attn (nn.Module): Attention layer (MLA).
+        ffn (nn.Module): Feed-forward network (MLP or MoE).
+        attn_norm (nn.Module): Layer normalization for attention.
+        ffn_norm (nn.Module): Layer normalization for feed-forward network.
+    """
+    def __init__(self, layer_id: int, args: ModelArgs):
+        """
+        Initializes the Transformer block.
+
+        Args:
+            layer_id (int): Layer index in the transformer.
+            args (ModelArgs): Model arguments containing block parameters.
+        """
+        super().__init__()
+        self.attn = FlashMHA(args)
+        self.ffn = MLP(args.dim, args.inter_dim) if layer_id < args.n_dense_layers else MoE(args)
+        self.attn_norm = RMSNorm(args.dim)
+        self.ffn_norm = RMSNorm(args.dim)
+
+    def forward(self, x: torch.Tensor, start_pos: int, freqs_cis: torch.Tensor, mask: Optional[torch.Tensor]) -> torch.Tensor:
+        """
+        Forward pass for the Transformer block.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+            start_pos (int): Starting position in the sequence.
+            freqs_cis (torch.Tensor): Precomputed complex exponential values for rotary embeddings.
+            mask (Optional[torch.Tensor]): Mask tensor to exclude certain positions from attention.
+
+        Returns:
+            torch.Tensor: Output tensor after block computation.
+        """
+        x = x + self.attn(self.attn_norm(x), start_pos, freqs_cis, mask)
+        x = x + self.ffn(self.ffn_norm(x))
+        return x
+
+
+class Transformer(nn.Module):
+    """
+    Transformer model with positional embeddings, multiple layers, and output projection.
+
+    Attributes:
+        max_seq_len (int): Maximum sequence length for the transformer.
+        embed (nn.Module): Embedding layer for input tokens.
+        layers (torch.nn.ModuleList): List of transformer blocks.
+        norm (nn.Module): Layer normalization applied after all blocks.
+        head (nn.Module): Output projection layer mapping to vocabulary size.
+        freqs_cis (torch.Tensor): Precomputed complex exponential values for rotary embeddings.
+    """
+    def __init__(self, args: ModelArgs):
+        """
+        Initializes the Transformer model.
+
+        Args:
+            args (ModelArgs): Model arguments containing transformer parameters.
+        """
+        global world_size, rank
+        world_size = dist.get_world_size() if dist.is_initialized() else 1
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        Linear.dtype = torch.float8_e4m3fn if args.dtype == "fp8" else torch.bfloat16
+        super().__init__()
+        self.max_seq_len = args.max_seq_len
+        self.embed = ParallelEmbedding(args.vocab_size, args.dim)
+        self.layers = torch.nn.ModuleList()
+        for layer_id in range(args.n_layers):
+            self.layers.append(Block(layer_id, args))
+        self.norm = RMSNorm(args.dim)
+        self.head = ColumnParallelLinear(args.dim, args.vocab_size, dtype=torch.get_default_dtype())
+        self.register_buffer("freqs_cis", precompute_freqs_cis(args), persistent=False)
+
+    @torch.inference_mode()
+    def forward(self, tokens: torch.Tensor, start_pos: int = 0):
+        """
+        Forward pass for the Transformer model.
+
+        Args:
+            tokens (torch.Tensor): Input tensor of token IDs with shape (batch_size, seq_len).
+            start_pos (int, optional): Starting position in the sequence for rotary embeddings. Defaults to 0.
+
+        Returns:
+            torch.Tensor: Logits tensor of shape (batch_size, vocab_size).
+        """
+        seqlen = tokens.size(1)
+        h = self.embed(tokens)
+        freqs_cis = self.freqs_cis[start_pos:start_pos+seqlen]
+        mask = None
+        if seqlen > 1:
+            mask = torch.full((seqlen, seqlen), float("-inf"), device=tokens.device).triu_(1)
+        for layer in self.layers:
+            h = layer(h, start_pos, freqs_cis, mask)
+        h = self.norm(h)[:, -1]
+        logits = self.head(h)
+        if world_size > 1:
+            all_logits = [torch.empty_like(logits) for _ in range(world_size)]
+            dist.all_gather(all_logits, logits)
+            logits = torch.cat(all_logits, dim=-1)
+        return logits
+
+if __name__ == "__main__":
+    #torch.set_default_dtype(torch.float16)
+    #torch.set_default_device("cuda")
+    torch.manual_seed(0)
+
+    #args = ModelArgs()
+    #model = Transformer(args).cuda()
+    args = ModelArgs()
+    model = Transformer(args)                  # weights stay on CPU
+    model.to(device="cuda", dtype=torch.float16)  # single, contiguous move
+    model.eval()                               # turn off dropout etc.
+
+    tokens = torch.randint(0, args.vocab_size, (2, 128), device="cuda")
+    with torch.inference_mode():
+        logits = model(tokens)
+    print("OK – logits shape:", logits.shape)   
+
+    #dummy_tokens = torch.randint(0, args.vocab_size, (2, 128), device="cuda")
+    #out = model(dummy_tokens)
+    #print("Logits shape:", out.shape)  # should be (2, vocab_size)
+
+
+'''
+if __name__ == "__main__":
+    torch.set_default_dtype(torch.bfloat16)
+    torch.set_default_device("cuda")
+    torch.manual_seed(0)
+    args = ModelArgs()
+    x = torch.randint(0, args.vocab_size, (2, 128))
+    model = Transformer(args)
+    print(model(x).size())
+'''


### PR DESCRIPTION
Initial working attempt paged attention. Performance comparison:

$ python benchmark_attn_qlora.py deepseek-ai/deepseek-coder-1.3b-base configs/paged.json runs/testing
paged

=== BENCHMARK SUMMARY ===
{'impl': 'paged', 'train_runtime_s': 1.3, 'train_samples_per_s': 8.382, 'eval_samples_per_s': 46.937, 'gen_tok_per_s': 64.43, 'peak_mem_MiB': 3896, 'train_loss': 5.7499, 'val_loss': 5.8337, 'val_ppl': 341.63, 'rouge1': np.float64(0.0), 'rouge2': np.float64(0.0), 'rougeL': np.float64(0.0), 'trainable_params_M': 12.6, 'total_params_M': 751.9}


$ python benchmark_attn_qlora.py deepseek-ai/deepseek-coder-1.3b-base configs/test.json runs/bench
['eager', 'sdpa', 'flash_attention_2']

=== BENCHMARK SUMMARY ===
{'impl': 'eager', 'train_runtime_s': 2.6, 'train_samples_per_s': 4.154, 'eval_samples_per_s': 38.831, 'gen_tok_per_s': 52.98, 'peak_mem_MiB': 3896, 'train_loss': 2.5828, 'val_loss': 2.6754, 'val_ppl': 14.52, 'rouge1': np.float64(0.1605), 'rouge2': np.float64(0.0218), 'rougeL': np.float64(0.1392), 'trainable_params_M': 12.6, 'total_params_M': 751.9}
{'impl': 'sdpa', 'train_runtime_s': 1.3, 'train_samples_per_s': 9.134, 'eval_samples_per_s': 43.085, 'gen_tok_per_s': 55.92, 'peak_mem_MiB': 4949, 'train_loss': 2.5294, 'val_loss': 2.6173, 'val_ppl': 13.7, 'rouge1': np.float64(0.1605), 'rouge2': np.float64(0.0218), 'rougeL': np.float64(0.1392), 'trainable_params_M': 12.6, 'total_params_M': 751.9}
{'impl': 'flash_attention_2', 'train_runtime_s': 1.3, 'train_samples_per_s': 8.919, 'eval_samples_per_s': 42.79, 'gen_tok_per_s': 47.18, 'peak_mem_MiB': 4949, 'train_loss': 2.5152, 'val_loss': 2.6163, 'val_ppl': 13.68, 'rouge1': np.float64(0.1605), 'rouge2': np.float64(0.0218), 'rougeL': np.float64(0.1392), 'trainable_params_M': 12.6, 'total_params_M': 751.9}
